### PR TITLE
added overflow: hidden; for nav-bar (less)

### DIFF
--- a/app/css/main.less
+++ b/app/css/main.less
@@ -355,7 +355,7 @@ ul {
 			*/
 
 			.nav-bar {
-
+				overflow: hidden;
 				.label-toggle { visibility: visible; }
 
 				ul {


### PR DESCRIPTION
Added overflow: hidden; for nav-bar to hide the horizontal scrolling when the menu is hidden ( w < 768px )